### PR TITLE
🐛 no dnascope for clr

### DIFF
--- a/docs/PACBIO_WORKFLOW_README.md
+++ b/docs/PACBIO_WORKFLOW_README.md
@@ -45,7 +45,7 @@ information on our collaborators, check out their websites:
 1. Generate structural variant calls from the `minimap2_aligned_bam` using pbsv.
 1. Generate structural variant calls from the `minimap2_aligned_bam` using Sniffles.
 1. Generate structural variant calls from the `minimap2_aligned_bam` using Sentieon LongReadSV.
-1. Generate small variant from the `minimap2_aligned_bam` using Sentieon DNAScope HiFi.
+1. If the reads are not CLR, Generate small variant from the `minimap2_aligned_bam` using Sentieon DNAScope HiFi.
 
 ## Basic Info
 - [D3b dockerfiles](https://github.com/d3b-center/bixtools)

--- a/workflows/kfdrc-pacbio-longreads-workflow.cwl
+++ b/workflows/kfdrc-pacbio-longreads-workflow.cwl
@@ -50,7 +50,7 @@ doc: |
   1. Generate structural variant calls from the `minimap2_aligned_bam` using pbsv.
   1. Generate structural variant calls from the `minimap2_aligned_bam` using Sniffles.
   1. Generate structural variant calls from the `minimap2_aligned_bam` using Sentieon LongReadSV.
-  1. Generate small variant from the `minimap2_aligned_bam` using Sentieon DNAScope HiFi.
+  1. If the reads are not CLR, Generate small variant from the `minimap2_aligned_bam` using Sentieon DNAScope HiFi.
 
   ## Basic Info
   - [D3b dockerfiles](https://github.com/d3b-center/bixtools)
@@ -230,7 +230,9 @@ steps:
     out: [output]
   dnascope:
     run: ../tools/sentieon_DNAscope_LongRead.cwl
+    when: $(inputs.minimap2_preset != "map-pb")
     in:
+      minimap2_preset: minimap2_preset
       sentieon_license: sentieon_license
       reference: indexed_reference_fasta
       input_bam: clt_pickvalue/outfile


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

CLR reads are no longer fed into DNAscope HIFI tool.

Closes https://github.com/d3b-center/bixu-tracker/issues/2047

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] https://cavatica.sbgenomics.com/u/kfdrc-harmonization/sd-46sk55a3-long-reads-mutations/tasks/a21da73d-587b-4ac0-a9e2-1eb3580d6547/#

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
